### PR TITLE
feat: Add support for the global version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,19 @@ https://g-otkk6267-helm.pkg.coding.net/Charts/safeline
 # add repo
 helm repo add safeline https://g-otkk6267-helm.pkg.coding.net/Charts/safeline
 # install sample
-helm install safeline --namespace safeline --set global.ingress.enabled=true --set global.ingress.hostname="waf.local"  safeline-lts/safeline-lts
+helm install safeline --namespace safeline \
+  --set global.ingress.enabled=true \
+  --set global.ingress.hostname="waf.local" \
+  safeline/safeline
+
+# install the global version
+helm install safeline --namespace safeline \
+  --set global.ingress.enabled=true \
+  --set global.ingress.hostname="waf.local" \
+  --set global.image.registry=chaitin \
+  --set global.image.region="-g" \
+  safeline/safeline
+
 # upgrade
 helm -n safeline upgrade safeline safeline/safeline
 # fetch chart

--- a/safeline/charts/templates/chaos/chaos-dpl.yaml
+++ b/safeline/charts/templates/chaos/chaos-dpl.yaml
@@ -63,7 +63,7 @@ spec:
       {{- end }}
       containers:
       - name: chaos
-        image: {{ default .Values.global.image.registry .Values.chaos.image.registry }}/{{ .Values.chaos.image.repository }}:{{ default .Chart.AppVersion .Values.chaos.image.tag }}
+        image: {{ default .Values.global.image.registry .Values.chaos.image.registry }}/{{ .Values.chaos.image.repository }}{{ .Values.global.image.region }}:{{ default .Chart.AppVersion .Values.chaos.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         ports:
           - name: stpp

--- a/safeline/charts/templates/detector/detector-dpl.yaml
+++ b/safeline/charts/templates/detector/detector-dpl.yaml
@@ -38,7 +38,7 @@ spec:
       {{- if .Values.global.exposeServicesAsPorts.enabled }}
       initContainers:
       - name: port-form-exposure-service
-        image: {{ default .Values.global.image.registry .Values.detector.image.registry }}/{{ .Values.detector.image.repository }}:{{ default .Chart.AppVersion .Values.detector.image.tag }}
+        image: {{ default .Values.global.image.registry .Values.detector.image.registry }}/{{ .Values.detector.image.repository }}{{ .Values.global.image.region }}:{{ default .Chart.AppVersion .Values.detector.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
           - sh
@@ -53,7 +53,7 @@ spec:
       {{- end }}
       containers:
       - name: detector
-        image: {{ default .Values.global.image.registry .Values.detector.image.registry }}/{{ .Values.detector.image.repository }}:{{ default .Chart.AppVersion .Values.detector.image.tag }}
+        image: {{ default .Values.global.image.registry .Values.detector.image.registry }}/{{ .Values.detector.image.repository }}{{ .Values.global.image.region }}:{{ default .Chart.AppVersion .Values.detector.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         ports:
           - name: tcd

--- a/safeline/charts/templates/luigi/luigi-dpl.yaml
+++ b/safeline/charts/templates/luigi/luigi-dpl.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 120
       initContainers:
       - name: init-probe
-        #image: {{ default .Values.global.image.registry .Values.luigi.image.registry }}/{{ .Values.luigi.image.repository }}:{{ default .Chart.AppVersion .Values.luigi.image.tag }}
+        #image: {{ default .Values.global.image.registry .Values.luigi.image.registry }}/{{ .Values.luigi.image.repository }}{{ .Values.global.image.region }}:{{ default .Chart.AppVersion .Values.luigi.image.tag }}
         image: busybox
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
@@ -47,7 +47,7 @@ spec:
             while true; do sleep 3 && nc -zvw1 safeline-detector 8001 && nc -zvw1 safeline-mgt 1443 && exit 0 || sleep 3; done; exit 1
       containers:
       - name: luigi
-        image: {{ default .Values.global.image.registry .Values.luigi.image.registry }}/{{ .Values.luigi.image.repository }}:{{ default .Chart.AppVersion .Values.luigi.image.tag }}
+        image: {{ default .Values.global.image.registry .Values.luigi.image.registry }}/{{ .Values.luigi.image.repository }}{{ .Values.global.image.region }}:{{ default .Chart.AppVersion .Values.luigi.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         # command:
         # - sh

--- a/safeline/charts/templates/mgt/mgt-dpl.yaml
+++ b/safeline/charts/templates/mgt/mgt-dpl.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 120
       initContainers:
       - name: delete-lost-found-dir
-        image: {{ default .Values.global.image.registry .Values.mgt.image.registry }}/{{ .Values.mgt.image.repository }}:{{ default .Chart.AppVersion .Values.mgt.image.tag }}
+        image: {{ default .Values.global.image.registry .Values.mgt.image.registry }}/{{ .Values.mgt.image.repository }}{{ .Values.global.image.region }}:{{ default .Chart.AppVersion .Values.mgt.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
           - sh
@@ -49,7 +49,7 @@ spec:
             name: mgt
       containers:
       - name: mgt
-        image: {{ default .Values.global.image.registry .Values.mgt.image.registry }}/{{ .Values.mgt.image.repository }}:{{ default .Chart.AppVersion .Values.mgt.image.tag }}
+        image: {{ default .Values.global.image.registry .Values.mgt.image.registry }}/{{ .Values.mgt.image.repository }}{{ .Values.global.image.region }}:{{ default .Chart.AppVersion .Values.mgt.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         ports:
           - name: web

--- a/safeline/charts/templates/tengine/tengine-dpl.yaml
+++ b/safeline/charts/templates/tengine/tengine-dpl.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 120
       containers:
       - name: tengine
-        image: {{ default .Values.global.image.registry .Values.tengine.image.registry }}/{{ .Values.tengine.image.repository }}:{{ default .Chart.AppVersion .Values.tengine.image.tag }}
+        image: {{ default .Values.global.image.registry .Values.tengine.image.registry }}/{{ .Values.tengine.image.repository }}{{ .Values.global.image.region }}:{{ default .Chart.AppVersion .Values.tengine.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.global.exposeServicesAsPorts.enabled }}
         lifecycle:

--- a/safeline/charts/values.yaml
+++ b/safeline/charts/values.yaml
@@ -8,6 +8,7 @@ global:
   image:
     registry: swr.cn-east-3.myhuaweicloud.com/chaitin-safeline
     tag: ""
+    region: ""
   # 全局开启已端口模式暴露服务，牵扯修改服务暴露模式服务为：detector与chaos，打开此选项将增加多个configmap加载以及修改配置文件，会修改nginx.conf文件。
   # 建议此向保持开启状态
   exposeServicesAsPorts:
@@ -108,7 +109,7 @@ database:
     automountServiceAccountToken: false
     image:
       registry: ''
-      repository: postgres
+      repository: safeline-postgres
       tag: 15.2
     password: changeit
     shmSizeLimit: 512Mi


### PR DESCRIPTION
Add the region parameter after all mirrors to increase support for international version deployment.
Testing has been completed in Kubernetes, and the international version of the database is interoperable with the domestic version, with no compatibility issues.